### PR TITLE
Add optional appAccountToken parameter to launchBillingFlow()

### DIFF
--- a/dist/esm/definitions.d.ts
+++ b/dist/esm/definitions.d.ts
@@ -8,6 +8,7 @@ export interface BillingPluginPlugin {
     launchBillingFlow(options: {
         product: string;
         type: string;
+        appAccountToken?: string;
     }): Promise<{
         value: string;
     }>;

--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -46,6 +46,10 @@ public class BillingPlugin: CAPPlugin, CAPBridgedPlugin {
         for product in self.productList.products {
             if product.productIdentifier == productName {
                 let payment = SKMutablePayment(product: product)
+                // Only a valid UUID round-trips into the App Store Server Notification appAccountToken field.
+                if let token = call.getString("appAccountToken"), UUID(uuidString: token) != nil {
+                    payment.applicationUsername = token.lowercased()
+                }
                 observer = Observer(call: call, product: productName)
                 SKPaymentQueue.default().add(observer)
                 SKPaymentQueue.default().add(payment)

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -1,6 +1,6 @@
 export interface BillingPluginPlugin {
   querySkuDetails(options: {product: string, type: string}): Promise<{value: string}>;
-  launchBillingFlow(options: {product: string, type: string}): Promise<{value: string}>;
+  launchBillingFlow(options: {product: string, type: string, appAccountToken?: string}): Promise<{value: string}>;
   sendAck(options: {purchaseToken: string}): Promise<{value: string}>;
   finishTransaction(options: {transactionId: string}): Promise<{value: string}>;
 }


### PR DESCRIPTION
This adds an optional appAccountToken parameter to launchBillingFlow(). On iOS, the value is set on SKMutablePayment.applicationUsername.

The goal is to let the app tell Apple which user made the purchase. When this token is set, Apple includes it as appAccountToken in App Store Server Notifications v2 and in the App Store Server API. That means the server can match an incoming purchase notification to a specific user account without guessing.

Apple only guarantees the value will come back if it is a valid UUID string. Because of that, the plugin validates the token first. If it parses as a UUID, it gets assigned. If not, it is ignored and the plugin behaves exactly as it does today (no applicationUsername set). Callers that don't pass the parameter are unaffected.

References:
- https://developer.apple.com/documentation/storekit/skmutablepayment/applicationusername
- https://developer.apple.com/documentation/appstoreserverapi/appaccounttoken